### PR TITLE
Revert "using date object instead of timestamp"

### DIFF
--- a/src/mq.js
+++ b/src/mq.js
@@ -59,7 +59,7 @@ module.exports = class MQ extends EventEmitter {
     const message = {
       version,
       name,
-      timestamp: new Date(),
+      timestamp: Date.now(),
       payload: payload || {},
     };
     return Buffer.from(JSON.stringify(message));


### PR DESCRIPTION
This reverts commit 49dbec08ef47cc565f98792adb0e6c7e5be37a4f.